### PR TITLE
Update Board and Change Board Colors

### DIFF
--- a/Wordle.Domain/Wordle.cs
+++ b/Wordle.Domain/Wordle.cs
@@ -3,12 +3,12 @@
 namespace Wordle.Domain;
 public class Game
 {
-    public List<LetterScore> EvaluateGuess(string answer, Guess guess)
+    public List<LetterScore> EvaluateGuess(string answer, string guess)
     {
         int i = 0;
 
         List<LetterScore> letterScoresList = new List<LetterScore>();
-        foreach (char guessLetter in guess.Word.ToUpper())
+        foreach (char guessLetter in guess.ToUpper())
         {   
             LetterScore letterScore = new LetterScore()
             {

--- a/Wordle.Tests/WordleUnitTest.cs
+++ b/Wordle.Tests/WordleUnitTest.cs
@@ -14,11 +14,7 @@ public class WordleUnitTests
     [Fact]
     public void EvaluateGuess_WhenNoLetterIsInWord_ShouldReturnAllNotInWord()
     {
-        var incorrectGuess = new Guess()
-        {
-            Number = 1,
-            Word = "GROWN"
-        };
+        var incorrectGuess = "GROWN";
 
         Score[] expectedResult = {
             Score.NotInWord,
@@ -39,11 +35,7 @@ public class WordleUnitTests
     [Fact]
     public void EvaluateGuess_WhenFirstLetterIsCorrect_ShouldReturnOneCorrect()
     {
-        var guessWithFirstLetterCorrect = new Guess()
-        {
-            Number = 2,
-            Word = "ARBOR"
-        };
+        var guessWithFirstLetterCorrect = "ARBOR";
 
         Score[] expectedResult = {
             Score.Correct,
@@ -64,11 +56,7 @@ public class WordleUnitTests
     [Fact]
     public void EvaluateGuess_WhenFirstLetterIsInWord_ShouldReturnOneInWord()
     {
-        var guessWithFirstLetterInWord = new Guess()
-        {
-            Number = 3,
-            Word = "TOURS"
-        };
+        var guessWithFirstLetterInWord = "TOURS";
 
         Score[] expectedResult = {
             Score.InWord,
@@ -89,11 +77,7 @@ public class WordleUnitTests
     [Fact]
     public void EvaluateGuess_WhenOneLetterIsCorrectAndOneLetterIsInWord_ShouldReturnOneCorrectOneInWord()
     {
-        var guessWithOneCorrectAndOneInWord = new Guess()
-        {
-            Number = 4,
-            Word = "AUDIO"
-        };
+        var guessWithOneCorrectAndOneInWord = "AUDIO";
 
         Score[] expectedResult = {
             Score.Correct,
@@ -114,11 +98,7 @@ public class WordleUnitTests
     [Fact]
     public void EvaluateGuess_WhenPlayersEnterAnyCase_ShouldStillEvaluateCorrectly()
     {
-        var guessLowerCase = new Guess()
-        {
-            Number = 4,
-            Word = "audio"
-        };
+        var guessLowerCase = "audio";
 
         Score[] expectedResult = {
             Score.Correct,
@@ -139,11 +119,7 @@ public class WordleUnitTests
     [Fact]
     public void EvaluateGuess_WhenAllLettersAreInWord_ShouldReturnAllInWord()
     {
-        var guessAllLettersInWord = new Guess()
-        {
-            Number = 5,
-            Word = "TAPED"
-        };
+        var guessAllLettersInWord = "TAPED";
 
         Score[] expectedResult = {
             Score.InWord,
@@ -163,11 +139,7 @@ public class WordleUnitTests
     [Fact]
     public void EvaluateGuess_WhenAllLettersAreCorrect_ShouldReturnAllCorrect()
     {
-        var correctGuess = new Guess()
-        {
-            Number = 6,
-            Word = "ADEPT"
-        };
+        var correctGuess = "ADEPT";
 
         Score[] expectedResult = {
             Score.Correct,

--- a/Wordle.UI/Program.cs
+++ b/Wordle.UI/Program.cs
@@ -10,7 +10,7 @@ public static class Program
     {
         try
         {
-            int guessNum = 0;
+            int guessCount = 0;
             string secretWord = "ADEPT";
             WordScore[] wordScoreArray = new WordScore[6];
             var game = new Game();
@@ -20,14 +20,15 @@ public static class Program
             var guess = Console.ReadLine();
 
             if (guess != null)
-            {   
-                wordScoreArray[guessNum] = new WordScore()
+            {
+                guessCount++;
+                wordScoreArray[guessCount - 1] = new WordScore()
                 {
-                    GuessNumber = guessNum + 1,
+                    GuessNumber = guessCount,
                     LetterScores = game.EvaluateGuess(secretWord, guess)
                 };
-                guessNum++;
-                UpdateBoard(wordScoreArray, guessNum);
+
+                UpdateBoard(wordScoreArray, guessCount);
             }
         }
         catch (Exception error)
@@ -40,6 +41,7 @@ public static class Program
     private static void DisplayEmptyBoard()
     {
         Console.Clear();
+        Console.BackgroundColor = ConsoleColor.Black;
         Console.WriteLine(@"
  ╔═══╦═══╦═══╦═══╦═══╗
  ║   ║   ║   ║   ║   ║
@@ -84,21 +86,25 @@ public static class Program
     }
     private static void UpdateBoard(WordScore[] words, int guessCount)
     {
-        Console.Clear();
         var topBorder = "╔═══╦═══╦═══╦═══╦═══╗";
         var bottomBorder = "╚═══╩═══╩═══╩═══╩═══╝";
         var rowBorder = "╠═══╬═══╬═══╬═══╬═══╣";
         var emptyRow = "║   ║   ║   ║   ║   ║";
-        Console.WriteLine(topBorder); 
-        for(int i = 0; i < guessCount; i++)
-        {
-            DisplayRow(words[i]);
-            Console.WriteLine(rowBorder);
 
-        }
-        for(int i = guessCount; i <= 6; i++){
+        Console.Clear();
+        Console.WriteLine(topBorder);
+        
+        int i = 0;
+        while (i < 6)
+        {
+            while (i < guessCount)
+            {
+                DisplayRow(words[i]);
+                Console.WriteLine(rowBorder);
+                i++;
+            }
             Console.WriteLine(emptyRow);
-            if (i == 6)
+            if (i == 5)
             {
                 break;
             }
@@ -106,7 +112,8 @@ public static class Program
             {
                 Console.WriteLine(rowBorder);
             }
-        }  
+            i++;
+        }
         Console.WriteLine(bottomBorder);
     }
 }

--- a/Wordle.UI/Program.cs
+++ b/Wordle.UI/Program.cs
@@ -57,7 +57,7 @@ public static class Program
  ║   ║   ║   ║   ║   ║
  ╚═══╩═══╩═══╩═══╩═══╝");
     }
-    private static void DisplayCell(LetterScore letter)
+    private static void RenderCell(LetterScore letter)
     {
         if (letter.Eval == Score.Correct)
         {
@@ -75,12 +75,12 @@ public static class Program
         Console.BackgroundColor = ConsoleColor.Black;
     }
 
-    private static void DisplayRow(WordScore word)
+    private static void RenderRow(WordScore word)
     {
         foreach (LetterScore letter in word.LetterScores)
         {
             Console.Write("║");
-            DisplayCell(letter);
+            RenderCell(letter);
         }
         Console.Write("║" + Environment.NewLine);
     }
@@ -99,7 +99,7 @@ public static class Program
         {
             while (i < guessCount)
             {
-                DisplayRow(words[i]);
+                RenderRow(words[i]);
                 Console.WriteLine(rowBorder);
                 i++;
             }

--- a/Wordle.UI/Program.cs
+++ b/Wordle.UI/Program.cs
@@ -10,42 +10,24 @@ public static class Program
     {
         try
         {
+            int guessNum = 0;
+            string secretWord = "ADEPT";
+            WordScore[] wordScoreArray = new WordScore[6];
             var game = new Game();
-            Console.Clear();
-            Console.WriteLine(@"
- ╔═══╦═══╦═══╦═══╦═══╗
- ║   ║   ║   ║   ║   ║
- ╠═══╬═══╬═══╬═══╬═══╣
- ║   ║   ║   ║   ║   ║
- ╠═══╬═══╬═══╬═══╬═══╣
- ║   ║   ║   ║   ║   ║
- ╠═══╬═══╬═══╬═══╬═══╣
- ║   ║   ║   ║   ║   ║
- ╠═══╬═══╬═══╬═══╬═══╣
- ║   ║   ║   ║   ║   ║
- ╠═══╬═══╬═══╬═══╬═══╣
- ║   ║   ║   ║   ║   ║
- ╚═══╩═══╩═══╩═══╩═══╝");
+            DisplayEmptyBoard();
+
             Console.WriteLine("Type in your 5 letter guess, then hit enter:");
             var guess = Console.ReadLine();
 
             if (guess != null)
-            {
-                Console.Clear();
-                Console.WriteLine(@$"
- ╔═══╦═══╦═══╦═══╦═══╗
- ║ {guess[0]} ║ {guess[1]} ║ {guess[2]} ║ {guess[3]} ║ {guess[4]} ║
- ╠═══╬═══╬═══╬═══╬═══╣
- ║   ║   ║   ║   ║   ║
- ╠═══╬═══╬═══╬═══╬═══╣
- ║   ║   ║   ║   ║   ║
- ╠═══╬═══╬═══╬═══╬═══╣
- ║   ║   ║   ║   ║   ║
- ╠═══╬═══╬═══╬═══╬═══╣
- ║   ║   ║   ║   ║   ║
- ╠═══╬═══╬═══╬═══╬═══╣
- ║   ║   ║   ║   ║   ║
- ╚═══╩═══╩═══╩═══╩═══╝");
+            {   
+                wordScoreArray[guessNum] = new WordScore()
+                {
+                    GuessNumber = guessNum + 1,
+                    LetterScores = game.EvaluateGuess(secretWord, guess)
+                };
+                guessNum++;
+                UpdateBoard(wordScoreArray, guessNum);
             }
         }
         catch (Exception error)
@@ -53,6 +35,25 @@ public static class Program
             Console.WriteLine(error.Message);
         }
 
+    }
+
+    private static void DisplayEmptyBoard()
+    {
+        Console.Clear();
+        Console.WriteLine(@"
+ ╔═══╦═══╦═══╦═══╦═══╗
+ ║   ║   ║   ║   ║   ║
+ ╠═══╬═══╬═══╬═══╬═══╣
+ ║   ║   ║   ║   ║   ║
+ ╠═══╬═══╬═══╬═══╬═══╣
+ ║   ║   ║   ║   ║   ║
+ ╠═══╬═══╬═══╬═══╬═══╣
+ ║   ║   ║   ║   ║   ║
+ ╠═══╬═══╬═══╬═══╬═══╣
+ ║   ║   ║   ║   ║   ║
+ ╠═══╬═══╬═══╬═══╬═══╣
+ ║   ║   ║   ║   ║   ║
+ ╚═══╩═══╩═══╩═══╩═══╝");
     }
     private static void DisplayCell(LetterScore letter)
     {
@@ -79,7 +80,33 @@ public static class Program
             Console.Write("║");
             DisplayCell(letter);
         }
-        Console.Write("║");
+        Console.Write("║" + Environment.NewLine);
     }
+    private static void UpdateBoard(WordScore[] words, int guessCount)
+    {
+        Console.Clear();
+        var topBorder = "╔═══╦═══╦═══╦═══╦═══╗";
+        var bottomBorder = "╚═══╩═══╩═══╩═══╩═══╝";
+        var rowBorder = "╠═══╬═══╬═══╬═══╬═══╣";
+        var emptyRow = "║   ║   ║   ║   ║   ║";
+        Console.WriteLine(topBorder); 
+        for(int i = 0; i < guessCount; i++)
+        {
+            DisplayRow(words[i]);
+            Console.WriteLine(rowBorder);
 
+        }
+        for(int i = guessCount; i <= 6; i++){
+            Console.WriteLine(emptyRow);
+            if (i == 6)
+            {
+                break;
+            }
+            else
+            {
+                Console.WriteLine(rowBorder);
+            }
+        }  
+        Console.WriteLine(bottomBorder);
+    }
 }

--- a/Wordle.UI/Program.cs
+++ b/Wordle.UI/Program.cs
@@ -54,6 +54,24 @@ public static class Program
         }
 
     }
+    private static void DisplayCell(LetterScore letter)
+    {
+        if (letter.Eval == Score.Correct)
+        {
+            Console.BackgroundColor = ConsoleColor.DarkGreen;
+        }
+        else if (letter.Eval == Score.InWord)
+        {
+            Console.BackgroundColor = ConsoleColor.DarkYellow;
+        }
+        else
+        {
+            Console.BackgroundColor = ConsoleColor.DarkGray;
+        }
+        Console.Write($" {letter.Letter} ");
+        Console.BackgroundColor = ConsoleColor.Black;
+    }
+
     private static void DisplayRow(WordScore word)
     {
         foreach (LetterScore letter in word.LetterScores)
@@ -63,4 +81,5 @@ public static class Program
         }
         Console.Write("║");
     }
+
 }

--- a/Wordle.UI/Program.cs
+++ b/Wordle.UI/Program.cs
@@ -47,11 +47,20 @@ public static class Program
  ║   ║   ║   ║   ║   ║
  ╚═══╩═══╩═══╩═══╩═══╝");
             }
-        }            
+        }
         catch (Exception error)
         {
             Console.WriteLine(error.Message);
         }
 
+    }
+    private static void DisplayRow(WordScore word)
+    {
+        foreach (LetterScore letter in word.LetterScores)
+        {
+            Console.Write("║");
+            DisplayCell(letter);
+        }
+        Console.Write("║");
     }
 }


### PR DESCRIPTION
Adds
- private methods to Wordle.UI so that it can now DisplayEmptyBoard, UpdateBoard, RenderRow and RenderCell.
- Global wordScoreArray to keep track of accepted words + their letter evaluations
- guessCount to keep track of number of accepted guesses
- functionality to utilize letter evaluations to provide colorful console feedback to player about letter accuracy

Changes
- EvaluateLetter to accept a string rather than a Guess class.

https://user-images.githubusercontent.com/89801075/235794824-d5191ae4-72a2-4e4d-8a09-20a4b895853a.mov

I would love to get your thoughts on whether Wordle.UI is the correct place for this board functionality or if some belongs in the Wordle.Domain project? Also, is there better logic for UpdateBoard (instead of the two while loops)?